### PR TITLE
Standardize API calls and auto inject token

### DIFF
--- a/src/app/(main)/gestor/gestao-de-estagiarios/page.tsx
+++ b/src/app/(main)/gestor/gestao-de-estagiarios/page.tsx
@@ -1,22 +1,21 @@
 "use client"
 
-import type React from "react"
-import { useState } from "react"
+import React, { useState, useEffect, useCallback } from "react"
 import {
   Box,
   Button,
   Container,
   Typography,
-  Paper,
   IconButton,
   Avatar,
   Grid,
-  useTheme, // Importar useTheme
-  Menu, // Adicionado para o menu de ações da tabela
-  MenuItem, // Adicionado para o menu de ações da tabela
-  LinearProgress, // Adicionado para a barra de performance no StatCard
+  useTheme,
+  Menu,
+  MenuItem,
+  LinearProgress,
+  CircularProgress,
 } from "@mui/material"
-import { alpha } from "@mui/material/styles" // Importar alpha para cores translúcidas
+import { alpha } from "@mui/material/styles"
 
 // Icons
 import PersonAddIcon from "@mui/icons-material/PersonAdd"
@@ -24,112 +23,44 @@ import PeopleAltIcon from "@mui/icons-material/PeopleAlt"
 import EventNoteIcon from "@mui/icons-material/EventNote"
 import AssignmentTurnedInIcon from "@mui/icons-material/AssignmentTurnedIn"
 import TrendingUpIcon from "@mui/icons-material/TrendingUp"
-import RestaurantIcon from "@mui/icons-material/Restaurant" // Ícone para Nutrição
-import PsychologyIcon from "@mui/icons-material/Psychology" // Ícone para Psicologia
-import FitnessCenterIcon from "@mui/icons-material/FitnessCenter" // Ícone para Fisioterapia
-import MoreHorizIcon from '@mui/icons-material/MoreHoriz'; // Ícone de "Mais opções" para a tabela
-import VisibilityIcon from '@mui/icons-material/Visibility'; // Ícone "Ver detalhes"
-import EditIcon from '@mui/icons-material/Edit'; // Ícone "Editar"
+import RestaurantIcon from "@mui/icons-material/Restaurant"
+import PsychologyIcon from "@mui/icons-material/Psychology"
+import FitnessCenterIcon from "@mui/icons-material/FitnessCenter"
+import MoreHorizIcon from "@mui/icons-material/MoreHoriz"
+import VisibilityIcon from "@mui/icons-material/Visibility"
+import EditIcon from "@mui/icons-material/Edit"
 
+import { fetchInterns } from "@/app/lib/api/interns"
 import { usePushWithProgress } from "@/app/hooks/usePushWithProgress"
-
-// Importar os componentes da tela anterior (ajuste os caminhos conforme necessário)
 import { StatCard } from "@/app/components/ui/StatCard"
-import { DataTable } from "@/app/components/DataTable"
-import type { Intern } from "@/app/types";
-import { StyledBadge, IconContainer } from "@/app/components/DataTable" // Importar componentes auxiliares
+import { DataTable, StyledBadge, IconContainer } from "@/app/components/DataTable"
+import type { Intern } from "@/app/types"
 
-// Mock data
-// Adicionei performance e icons específicos para cada estagiário para compatibilidade com DataTable
-    name: "Ana Silva",
-    specialty: "Nutrição",
-    avatar: "", // Caminho real da imagem
-    appointmentsCompleted: 32,
-    appointmentsScheduled: 8,
-    status: "Ativo",
-    icon: <RestaurantIcon fontSize="small" />,
-    performance: 95,
-  },
-  {
-    id: 2,
-    name: "Carlos Mendes",
-    specialty: "Psicologia",
-    avatar: "",
-    appointmentsCompleted: 28,
-    appointmentsScheduled: 6,
-    status: "Inativo",
-    icon: <PsychologyIcon fontSize="small" />,
-    performance: 88,
-  },
-  {
-    id: 3,
-    name: "Juliana Costa",
-    specialty: "Fisioterapia",
-    avatar: "",
-    appointmentsCompleted: 18,
-    appointmentsScheduled: 4,
-    status: "Ativo",
-    icon: <FitnessCenterIcon fontSize="small" />,
-    performance: 92,
-  },
-  {
-    id: 4,
-    name: "Pedro Santos",
-    specialty: "Nutrição",
-    avatar: "",
-    appointmentsCompleted: 15,
-    appointmentsScheduled: 5,
-    status: "Ativo",
-    icon: <RestaurantIcon fontSize="small" />,
-    performance: 85,
-  },
-  {
-    id: 5,
-    name: "Mariana Lima",
-    specialty: "Psicologia",
-    avatar: "",
-    appointmentsCompleted: 22,
-    appointmentsScheduled: 7,
-    status: "Ativo",
-    icon: <PsychologyIcon fontSize="small" />,
-    performance: 90,
-  },
-  {
-    id: 6,
-    name: "Gabriel Souza",
-    specialty: "Fisioterapia",
-    avatar: "",
-    appointmentsCompleted: 19,
-    appointmentsScheduled: 3,
-    status: "Ativo",
-    icon: <FitnessCenterIcon fontSize="small" />,
-    performance: 87,
-  },
-]
-
-// Defina as colunas para a tabela de estagiários usando o formato do DataTable
 const internHeaders = [
-  { id: "name", label: "Estagiário" },
-  { id: "specialty", label: "Especialidade" },
-  { id: "appointmentsCompleted", label: "Consultas Realizadas" },
+  { id: "name",                  label: "Estagiário"          },
+  { id: "specialty",             label: "Especialidade"       },
+  { id: "appointmentsCompleted", label: "Consultas Realizadas"},
   { id: "appointmentsScheduled", label: "Consultas Agendadas" },
-  { id: "performance", label: "Performance" },
-  { id: "status", label: "Status" },
+  { id: "performance",           label: "Performance"         },
+  { id: "status",                label: "Status"              },
 ]
 
-// Função de renderização de célula para a DataTable
+// helper p/ specialty → ícone
+const specialtyIcon = (s: string) => {
+  switch (s) {
+    case "Nutrição":     return <RestaurantIcon fontSize="small" />
+    case "Psicologia":   return <PsychologyIcon fontSize="small" />
+    case "Fisioterapia": return <FitnessCenterIcon fontSize="small" />
+    default:             return null
+  }
+}
+
 const renderInternCell = (intern: Intern, headerId: string) => {
-  // O useTheme deve ser chamado dentro do componente funcional principal ou de um Hook
-  // Para fins de demonstração, simulamos o theme para a renderização da célula.
-  // Em um ambiente real, você passaria theme via contexto ou como prop se necessário,
-  // ou faria o StyledBadge e IconContainer encapsularem seu próprio tema.
-  // Para StyledBadge e IconContainer, eles já recebem o tema do ThemeProvider.
-  
   switch (headerId) {
     case "name":
       return (
         <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-          <Avatar src={intern.avatar} sx={{ width: 32, height: 32 }}>
+          <Avatar src={intern.avatar ?? undefined} sx={{ width: 32, height: 32 }}>
             {intern.name.split(" ").map((n) => n[0]).join("")}
           </Avatar>
           <Typography fontWeight={500}>{intern.name}</Typography>
@@ -138,7 +69,9 @@ const renderInternCell = (intern: Intern, headerId: string) => {
     case "specialty":
       return (
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-            <IconContainer sx={{ color: "primary.main" }}>{intern.icon}</IconContainer>
+          <IconContainer sx={{ color: "primary.main" }}>
+            {specialtyIcon(intern.specialty)}
+          </IconContainer>
           {intern.specialty}
         </Box>
       )
@@ -149,19 +82,12 @@ const renderInternCell = (intern: Intern, headerId: string) => {
     case "performance":
       return (
         <Box sx={{ display: "flex", alignItems: "center", gap: 1, width: 100 }}>
-          <LinearProgress
-            variant="determinate"
-            value={intern.performance}
-            sx={{ flexGrow: 1, height: 6, borderRadius: 3 }}
-          />
-          <Typography variant="caption" fontWeight={500}>
-            {intern.performance}%
-          </Typography>
+          <LinearProgress variant="determinate" value={intern.performance} sx={{ flexGrow: 1, height: 6, borderRadius: 3 }} />
+          <Typography variant="caption" fontWeight={500}>{intern.performance}%</Typography>
         </Box>
       )
     case "status":
-      // Mapeia o status para um tipo de badge compatível com StyledBadge
-      const badgeType = intern.status === "Ativo" ? "Confirmada" : "Pendente" // Ou crie um mapeamento mais específico
+      const badgeType = intern.status === "Ativo" ? "Confirmada" : "Pendente"
       return <StyledBadge label={intern.status} badgeType={badgeType} />
     default:
       return null
@@ -169,88 +95,86 @@ const renderInternCell = (intern: Intern, headerId: string) => {
 }
 
 export default function InternManagementScreen() {
-  const theme = useTheme() // Chamada do hook useTheme
+  const theme            = useTheme()
   const pushWithProgress = usePushWithProgress()
-  const [page, setPage] = useState(0)
-  const [rowsPerPage, setRowsPerPage] = useState(5)
 
-  // Estados para o menu de ações da tabela
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const [selectedIntern, setSelectedIntern] = useState<Intern | null>(null);
+  // paginação
+  const [page,        setPage]        = useState(0)   // ZERO-based
+  const [rowsPerPage, setRowsPerPage] = useState(10)
 
-  // Cálculo dos KPIs
-  const activeInterns = mockInterns.filter((intern) => intern.status === "Ativo").length
-  const totalAppointmentsCompleted = mockInterns.reduce((sum, intern) => sum + intern.appointmentsCompleted, 0)
-  const totalAppointmentsScheduled = mockInterns.reduce((sum, intern) => sum + intern.appointmentsScheduled, 0)
-  const averageAppointmentsPerIntern = activeInterns > 0 ? Math.round(totalAppointmentsCompleted / activeInterns) : 0
-  const occupancyRate =
-    activeInterns > 0 ? Math.round((totalAppointmentsScheduled / (activeInterns * 10)) * 100) : 0 // Assumindo capacidade de 10 consultas por estagiário
+  // dados
+  const [interns,     setInterns]     = useState<Intern[]>([])
+  const [totalCount,  setTotalCount]  = useState(0)
 
-  const handlePageChange = (event: unknown, newPage: number) => {
-    setPage(newPage)
-  }
+  // estados auxiliares
+  const [loading,     setLoading]     = useState(false)
+  const [error,       setError]       = useState<string | null>(null)
 
-  const handleRowsPerPageChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    setRowsPerPage(Number.parseInt(event.target.value, 10))
+  // menu de ações
+  const [anchorEl,        setAnchorEl]   = useState<null | HTMLElement>(null)
+  const [selectedIntern,  setSelectedIntern] = useState<Intern | null>(null)
+
+  // userId → disponível no contexto/Redux/etc.
+  const currentUserId = 1  // ajuste
+
+  const loadInterns = useCallback(async () => {
+    setLoading(true);
+    try {
+      const { data, meta } = await fetchInterns(currentUserId, page + 1, rowsPerPage);
+      setInterns(data);
+      setTotalCount(meta.pagination.total);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [currentUserId, page, rowsPerPage]);
+
+  useEffect(() => {
+    loadInterns()
+  }, [loadInterns])
+
+  // KPIs
+  const activeInterns              = interns.filter((i) => i.status === "Ativo").length
+  const totalAppointmentsCompleted = interns.reduce((sum, i) => sum + i.appointmentsCompleted, 0)
+  const totalAppointmentsScheduled = interns.reduce((sum, i) => sum + i.appointmentsScheduled, 0)
+  const averageAppointments        = activeInterns ? Math.round(totalAppointmentsCompleted / activeInterns) : 0
+  const occupancyRate              = activeInterns ? Math.round((totalAppointmentsScheduled / (activeInterns * 10)) * 100) : 0
+
+  // handlers tabela
+  const handlePageChange = (_: unknown, newPage: number) => setPage(newPage)
+  const handleRowsPerPageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(e.target.value, 10))
     setPage(0)
   }
 
-  const paginatedData = mockInterns.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-
-  // Funções para o menu de ações da tabela
-  const handleMenuClick = (event: React.MouseEvent<HTMLElement>, intern: Intern) => {
-    setAnchorEl(event.currentTarget);
-    setSelectedIntern(intern);
-  };
-
-  const handleMenuClose = () => {
-    setAnchorEl(null);
-    setSelectedIntern(null);
-  };
-
+  // menu ações
+  const handleMenuClick = (e: React.MouseEvent<HTMLElement>, intern: Intern) => {
+    setAnchorEl(e.currentTarget)
+    setSelectedIntern(intern)
+  }
+  const handleMenuClose   = () => { setAnchorEl(null); setSelectedIntern(null) }
   const handleViewDetails = () => {
-    if (selectedIntern) {
-      console.log('Ver detalhes do estagiário:', selectedIntern);
-      pushWithProgress(`/gestor/estagiarios/${selectedIntern.id}`); // Exemplo de navegação
-    }
-    handleMenuClose();
-  };
+    if (selectedIntern) pushWithProgress(`/gestor/estagiarios/${selectedIntern.id}`)
+    handleMenuClose()
+  }
+  const handleEditIntern  = () => {
+    if (selectedIntern) pushWithProgress(`/gestor/estagiarios/editar/${selectedIntern.id}`)
+    handleMenuClose()
+  }
 
-  const handleEditIntern = () => {
-    if (selectedIntern) {
-      console.log('Editar estagiário:', selectedIntern);
-      pushWithProgress(`/gestor/estagiarios/editar/${selectedIntern.id}`); // Exemplo de navegação
-    }
-    handleMenuClose();
-  };
-
-  // Função para renderizar as ações da tabela, passada para o DataTable
   const internActions = (intern: Intern) => (
-    <IconButton
-      size="small"
-      onClick={(e) => handleMenuClick(e, intern)} // Passa o evento e a linha para o handler
-      sx={{ color: "text.secondary" }}
-    >
+    <IconButton size="small" onClick={(e) => handleMenuClick(e, intern)} sx={{ color: "text.secondary" }}>
       <MoreHorizIcon fontSize="small" />
     </IconButton>
-  );
+  )
 
   return (
     <Container maxWidth="xl" sx={{ mt: 4 }}>
-      <Box
-        sx={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          mb: 3,
-        }}
-      >
-        <Typography variant="h5" fontWeight={700}>
-          Gestão de Estagiários
-        </Typography>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 3 }}>
+        <Typography variant="h5" fontWeight={700}>Gestão de Estagiários</Typography>
         <Button
           variant="contained"
-          color="primary"
           startIcon={<PersonAddIcon />}
           onClick={() => pushWithProgress("gestao-de-estagiarios/cadastro")}
         >
@@ -258,7 +182,7 @@ export default function InternManagementScreen() {
         </Button>
       </Box>
 
-      {/* Dashboard de KPIs usando StatCard */}
+      {/* KPIs */}
       <Grid container spacing={3} mb={4}>
         <Grid item xs={12} sm={6} md={3}>
           <StatCard
@@ -281,7 +205,7 @@ export default function InternManagementScreen() {
         <Grid item xs={12} sm={6} md={3}>
           <StatCard
             title="Média por Estagiário"
-            value={averageAppointmentsPerIntern}
+            value={averageAppointments}
             subtitle="Média de consultas por estagiário ativo"
             icon={<TrendingUpIcon sx={{ color: theme.palette.success.main }} />}
             iconBgColor={alpha(theme.palette.success.main, 0.1)}
@@ -303,9 +227,7 @@ export default function InternManagementScreen() {
                   height: 8,
                   borderRadius: 4,
                   bgcolor: alpha(theme.palette.success.main, 0.2),
-                  "& .MuiLinearProgress-bar": {
-                    bgcolor: theme.palette.success.main,
-                  },
+                  "& .MuiLinearProgress-bar": { bgcolor: theme.palette.success.main },
                 }}
               />
             }
@@ -313,31 +235,35 @@ export default function InternManagementScreen() {
         </Grid>
       </Grid>
 
-      {/* Tabela de Gestão de Estagiários usando DataTable */}
+      {/* Tabela */}
+      {error && <Typography color="error" mb={2}>{error}</Typography>}
       <DataTable<Intern>
         title="Gestão de Estagiários"
         subtitle="Acompanhe o desempenho e atividades dos estagiários"
         headers={internHeaders}
-        data={paginatedData}
+        data={interns}
         renderCell={renderInternCell}
-        rowKeyExtractor={(intern) => intern.id}
+        rowKeyExtractor={(i) => i.id}
         actionsColumnLabel="Ações"
-        actions={internActions} // Passar as ações da tabela (o IconButton com MoreHorizIcon)
-        totalCount={mockInterns.length}
+        actions={internActions}
+        totalCount={totalCount}
         page={page}
         rowsPerPage={rowsPerPage}
         onPageChange={handlePageChange}
         onRowsPerPageChange={handleRowsPerPageChange}
-        emptyMessage="Nenhum estagiário encontrado."
+        emptyMessage={loading ? "Carregando..." : "Nenhum estagiário encontrado."}
       />
 
-      {/* Menu de ações da tabela (fora do DataTable) */}
+      {/* loading overlay quando DataTable não suporta isLoading */}
+      {loading && <CircularProgress sx={{ position: "absolute", top: "50%", left: "50%", mt: "-20px", ml: "-20px" }} />}
+
+      {/* Menu */}
       <Menu
         anchorEl={anchorEl}
         open={Boolean(anchorEl)}
         onClose={handleMenuClose}
-        transformOrigin={{ horizontal: "right", vertical: "top" }}
-        anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
+        transformOrigin={{ horizontal: "right",  vertical: "top" }}
+        anchorOrigin={{   horizontal: "right",  vertical: "bottom" }}
       >
         <MenuItem onClick={handleViewDetails}>
           <VisibilityIcon fontSize="small" sx={{ mr: 1 }} />

--- a/src/app/(main)/paciente/agendamento/page.tsx
+++ b/src/app/(main)/paciente/agendamento/page.tsx
@@ -160,9 +160,6 @@ export default function AgendarConsultaPage() {
 
       await apiFetch('/api/appointments', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify(payload),
       });
 

--- a/src/app/(main)/perfil/page.tsx
+++ b/src/app/(main)/perfil/page.tsx
@@ -62,9 +62,6 @@ export default function PerfilPage() {
     try {
       const res = await apiFetch(`/api/users/${user.id}`, {
         method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
         body: JSON.stringify({
           user: {
             name: newName,

--- a/src/app/auth/cadastro/page.tsx
+++ b/src/app/auth/cadastro/page.tsx
@@ -91,9 +91,6 @@ export default function RegisterPage() {
         token: string;
       }>("/api/users", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
         body: JSON.stringify({
           user: {
             name: formData.name,

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -38,9 +38,6 @@ export default function LoginPage() {
         "/login",
         {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
           body: JSON.stringify({ email, password }),
         }
       );

--- a/src/app/lib/api.ts
+++ b/src/app/lib/api.ts
@@ -1,3 +1,5 @@
+import Cookies from 'js-cookie';
+
 export async function apiFetch<T = unknown>(
   url: string,
   options: RequestInit = {},
@@ -6,11 +8,25 @@ export async function apiFetch<T = unknown>(
   const baseUrl = process.env.NEXT_PUBLIC_API_HOST;
   if (!baseUrl) throw new Error("API_HOST não definido nas variáveis de ambiente.");
 
+  let token: string | undefined;
+  try {
+    if (typeof window !== 'undefined') {
+      const storage = localStorage.getItem('session') ?? Cookies.get('session');
+      if (storage) {
+        const parsed = JSON.parse(storage);
+        token = parsed?.token;
+      }
+    }
+  } catch {
+    token = undefined;
+  }
+
   const res = await fetch(`${baseUrl}${url}`, {
     ...options,
     cache,
     headers: {
       "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
       ...options.headers,
     },
   });

--- a/src/app/lib/api.ts
+++ b/src/app/lib/api.ts
@@ -40,7 +40,6 @@ export async function apiFetch<T = unknown>(
   if (res.status === 204) return undefined as unknown as T;             // 204 No Content
   const ct = res.headers.get("content-type") ?? "";
   if (!ct.includes("application/json")) {
-    // se não for JSON devolve texto/bruto
     return (await res.text()) as unknown as T;
   }
 

--- a/src/app/lib/api/interns.ts
+++ b/src/app/lib/api/interns.ts
@@ -1,0 +1,33 @@
+// src/app/lib/api/interns.ts
+import { apiFetch } from "@/app/lib/api";
+import type { Intern, PaginatedResponse, MetaWithPagination } from "@/app/types";
+
+export async function fetchInterns(
+  userId: number,
+  page: number,
+  size: number,
+  extraParams = ""
+): Promise<PaginatedResponse<Intern>> {
+  const query = `page[number]=${page}&page[size]=${size}${extraParams}`;
+  const raw   = await apiFetch<{
+    data: Intern[];
+    meta: Record<string, unknown>;
+  }>(`/api/users/${userId}/interns?${query}`);
+
+  // ---------------- normalização do meta ----------------
+  const meta = raw.meta as MetaWithPagination;
+
+  const pagination =
+    meta.pagination ??
+    {
+      total:        Number(meta.total_count ?? 0),
+      per_page:     Number(meta.per_page ?? 0),
+      current_page: Number(meta.current_page ?? 0),
+      total_pages:  Number(meta.total_pages ?? 0),
+    };
+
+  return {
+    data: raw.data,
+    meta: { pagination },
+  };
+}

--- a/src/app/types/api.ts
+++ b/src/app/types/api.ts
@@ -1,0 +1,21 @@
+export interface PaginatedResponse<T> {
+  data: T[];
+  meta: {
+    pagination: {
+      total: number;
+      per_page: number;
+      current_page: number;
+      total_pages: number;
+    };
+  };
+}
+
+export type MetaWithPagination = {
+  pagination?: {
+    total: number;
+    per_page: number;
+    current_page: number;
+    total_pages: number;
+  };
+  [key: string]: unknown;
+};

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -3,3 +3,4 @@ export * from './ui';
 export * from './domain';
 export * from './forms';
 export * from './calendar';
+export * from './api';


### PR DESCRIPTION
## Summary
- centralize token handling in `apiFetch`
- simplify API calls by removing extra headers

## Testing
- `npx next lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840877c448c832cbd2113d302435d5c